### PR TITLE
ci: publish to GitLab Package Repository instead of GitHub as GitHub Packages does not allow unauthorized read access to Maven repository

### DIFF
--- a/.github/gitlab-mvn-settings.xml
+++ b/.github/gitlab-mvn-settings.xml
@@ -1,0 +1,16 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
+    <servers>
+        <server>
+            <id>gitlab</id>
+            <configuration>
+                <httpHeaders>
+                    <property>
+                        <name>Deploy-Token</name>
+                        <value>${env.GITLAB_DEPLOY_TOKEN}</value>
+                    </property>
+                </httpHeaders>
+            </configuration>
+        </server>
+    </servers>
+</settings>

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -23,5 +23,5 @@ jobs:
       - name: Build
         run: mvn --batch-mode compile
 
-      - name: Test
-        run: mvn --batch-mode verify
+      - name: Test and package
+        run: mvn --batch-mode package

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Github Packages
+name: Deploy to GitLab Package Repository # Github Packages
 
 on:
   release:
@@ -22,7 +22,7 @@ jobs:
           key: ${{ runner.os }}-m2-v8-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2-v8
 
-      - name: Deploy to GitHub Packages
+      - name: Deploy to GitLab Package Repository # GitHub Packages
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn --batch-mode deploy
+          GITLAB_DEPLOY_TOKEN: ${{ secrets.GITLAB_DEPLOY_TOKEN }} # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn --batch-mode -s .github/gitlab-mvn-settings.xml deploy

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>30.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -141,8 +141,10 @@
         </plugins>
     </build>
 
-    <!-- For publishing the library to GitHub Packages -->
+    <!-- For publishing the library to GitHub Packages/GitLab Package Repository -->
     <distributionManagement>
+        <!-- Github Packages does not currently support public access, so disabled until it does.
+             See https://github.community/t/download-from-github-package-registry-without-authentication/14407
         <repository>
             <id>github</id>
             <url>https://maven.pkg.github.com/web-eid/web-eid-authtoken-validation-java</url>
@@ -150,6 +152,15 @@
         <snapshotRepository>
             <id>github</id>
             <url>https://maven.pkg.github.com/web-eid/web-eid-authtoken-validation-java</url>
+        </snapshotRepository>
+        -->
+        <repository>
+            <id>gitlab</id>
+            <url>https://gitlab.com/api/v4/projects/19948337/packages/maven</url>
+        </repository>
+        <snapshotRepository>
+            <id>gitlab</id>
+            <url>https://gitlab.com/api/v4/projects/19948337/packages/maven</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
Resolves #7 