### PR TITLE
fix: use system time in OcspResponseValidator.validateCertificateStatusUpdateTime()

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ The following additional configuration options are available in `AuthTokenValida
 - `withOcspRequestTimeout(Duration ocspRequestTimeout)` – sets both the connection and response timeout of user certificate revocation check OCSP requests. Default is 5 seconds.
 - `withDisallowedCertificatePolicies(ASN1ObjectIdentifier... policies)` – adds the given policies to the list of disallowed user certificate policies. In order for the user certificate to be considered valid, it must not contain any policies present in this list. Contains the Estonian Mobile-ID policies by default as it must not be possible to authenticate with a Mobile-ID certificate when an eID smart card is expected.
 - `withNonceDisabledOcspUrls(URI... urls)` – adds the given URLs to the list of OCSP responder access location URLs for which the nonce protocol extension will be disabled. Some OCSP responders don't support the nonce extension.
+- `withAllowedOcspResponseTimeSkew(Duration allowedTimeSkew)` – sets the allowed time skew for OCSP response's `thisUpdate` and `nextUpdate` times to allow discrepancies between the system clock and the OCSP responder's clock or revocation updates that are not published in real time. The default allowed time skew is 15 minutes. The relatively long default is specifically chosen to account for one particular OCSP responder that used CRLs for authoritative revocation info, these CRLs were updated every 15 minutes.
+- `withMaxOcspResponseThisUpdateAge(Duration maxThisUpdateAge)` – sets the maximum age for the OCSP response's `thisUpdate` time before it is considered too old to rely on. The default maximum age is 2 minutes.
 
 Extended configuration example:  
 
@@ -312,6 +314,8 @@ AuthTokenValidator validator = new AuthTokenValidatorBuilder()
     .withoutUserCertificateRevocationCheckWithOcsp()
     .withDisallowedCertificatePolicies(new ASN1ObjectIdentifier("1.2.3"))
     .withNonceDisabledOcspUrls(URI.create("http://aia.example.org/cert"))
+    .withAllowedOcspResponseTimeSkew(Duration.ofMinutes(10))
+    .withMaxOcspResponseThisUpdateAge(Duration.ofMinutes(5))
     .build();
 ```
 

--- a/src/main/java/eu/webeid/security/certificate/CertificateValidator.java
+++ b/src/main/java/eu/webeid/security/certificate/CertificateValidator.java
@@ -23,9 +23,9 @@
 package eu.webeid.security.certificate;
 
 import eu.webeid.security.exceptions.CertificateExpiredException;
+import eu.webeid.security.exceptions.CertificateNotTrustedException;
 import eu.webeid.security.exceptions.CertificateNotYetValidException;
 import eu.webeid.security.exceptions.JceException;
-import eu.webeid.security.exceptions.CertificateNotTrustedException;
 
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
@@ -40,7 +40,6 @@ import java.security.cert.TrustAnchor;
 import java.security.cert.X509CertSelector;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -91,9 +90,8 @@ public final class CertificateValidator {
     }
 
     public static Set<TrustAnchor> buildTrustAnchorsFromCertificates(Collection<X509Certificate> certificates) {
-        return Collections.unmodifiableSet(certificates.stream()
-            .map(cert -> new TrustAnchor(cert, null))
-            .collect(Collectors.toSet()));
+        return certificates.stream()
+            .map(cert -> new TrustAnchor(cert, null)).collect(Collectors.toUnmodifiableSet());
     }
 
     public static CertStore buildCertStoreFromCertificates(Collection<X509Certificate> certificates) throws JceException {

--- a/src/main/java/eu/webeid/security/validator/AuthTokenValidatorBuilder.java
+++ b/src/main/java/eu/webeid/security/validator/AuthTokenValidatorBuilder.java
@@ -128,6 +128,38 @@ public class AuthTokenValidatorBuilder {
     }
 
     /**
+     * Sets the allowed time skew for OCSP response's thisUpdate and nextUpdate times.
+     * This parameter is used to allow discrepancies between the system clock and the OCSP responder's clock,
+     * which may occur due to clock drift, network delays or revocation updates that are not published in real time.
+     * <p>
+     * This is an optional configuration parameter, the default is 15 minutes.
+     * The relatively long default is specifically chosen to account for one particular OCSP responder that used
+     * CRLs for authoritative revocation info, these CRLs were updated every 15 minutes.
+     *
+     * @param allowedTimeSkew the allowed time skew
+     * @return the builder instance for method chaining.
+     */
+    public AuthTokenValidatorBuilder withAllowedOcspResponseTimeSkew(Duration allowedTimeSkew) {
+        configuration.setAllowedOcspResponseTimeSkew(allowedTimeSkew);
+        LOG.debug("Allowed OCSP response time skew set to {}", allowedTimeSkew);
+        return this;
+    }
+
+    /**
+     * Sets the maximum age of the OCSP response's thisUpdate time before it is considered too old.
+     * <p>
+     * This is an optional configuration parameter, the default is 2 minutes.
+     *
+     * @param maxThisUpdateAge the maximum age of the OCSP response's thisUpdate time
+     * @return the builder instance for method chaining.
+     */
+    public AuthTokenValidatorBuilder withMaxOcspResponseThisUpdateAge(Duration maxThisUpdateAge) {
+        configuration.setMaxOcspResponseThisUpdateAge(maxThisUpdateAge);
+        LOG.debug("Maximum OCSP response thisUpdate age set to {}", maxThisUpdateAge);
+        return this;
+    }
+
+    /**
      * Adds the given URLs to the list of OCSP URLs for which the nonce protocol extension will be disabled.
      * The OCSP URL is extracted from the user certificate and some OCSP services don't support the nonce extension.
      *

--- a/src/main/java/eu/webeid/security/validator/certvalidators/SubjectCertificateNotRevokedValidator.java
+++ b/src/main/java/eu/webeid/security/validator/certvalidators/SubjectCertificateNotRevokedValidator.java
@@ -52,6 +52,7 @@ import java.security.Security;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.util.Date;
 import java.util.Objects;
 
@@ -63,6 +64,8 @@ public final class SubjectCertificateNotRevokedValidator {
     private final SubjectCertificateTrustedValidator trustValidator;
     private final OcspClient ocspClient;
     private final OcspServiceProvider ocspServiceProvider;
+    private final Duration allowedOcspResponseTimeSkew;
+    private final Duration maxOcspResponseThisUpdateAge;
 
     static {
         Security.addProvider(new BouncyCastleProvider());
@@ -70,10 +73,14 @@ public final class SubjectCertificateNotRevokedValidator {
 
     public SubjectCertificateNotRevokedValidator(SubjectCertificateTrustedValidator trustValidator,
                                                  OcspClient ocspClient,
-                                                 OcspServiceProvider ocspServiceProvider) {
+                                                 OcspServiceProvider ocspServiceProvider,
+                                                 Duration allowedOcspResponseTimeSkew,
+                                                 Duration maxOcspResponseThisUpdateAge) {
         this.trustValidator = trustValidator;
         this.ocspClient = ocspClient;
         this.ocspServiceProvider = ocspServiceProvider;
+        this.allowedOcspResponseTimeSkew = allowedOcspResponseTimeSkew;
+        this.maxOcspResponseThisUpdateAge = maxOcspResponseThisUpdateAge;
     }
 
     /**
@@ -166,7 +173,7 @@ public final class SubjectCertificateNotRevokedValidator {
         //      be available about the status of the certificate (nextUpdate) is
         //      greater than the current time.
 
-        OcspResponseValidator.validateCertificateStatusUpdateTime(certStatusResponse);
+        OcspResponseValidator.validateCertificateStatusUpdateTime(certStatusResponse, allowedOcspResponseTimeSkew, maxOcspResponseThisUpdateAge);
 
         // Now we can accept the signed response as valid and validate the certificate status.
         OcspResponseValidator.validateSubjectCertificateStatus(certStatusResponse);

--- a/src/main/java/eu/webeid/security/validator/certvalidators/SubjectCertificateNotRevokedValidator.java
+++ b/src/main/java/eu/webeid/security/validator/certvalidators/SubjectCertificateNotRevokedValidator.java
@@ -166,7 +166,7 @@ public final class SubjectCertificateNotRevokedValidator {
         //      be available about the status of the certificate (nextUpdate) is
         //      greater than the current time.
 
-        OcspResponseValidator.validateCertificateStatusUpdateTime(certStatusResponse, producedAt);
+        OcspResponseValidator.validateCertificateStatusUpdateTime(certStatusResponse);
 
         // Now we can accept the signed response as valid and validate the certificate status.
         OcspResponseValidator.validateSubjectCertificateStatus(certStatusResponse);

--- a/src/main/java/eu/webeid/security/validator/ocsp/DigestCalculatorImpl.java
+++ b/src/main/java/eu/webeid/security/validator/ocsp/DigestCalculatorImpl.java
@@ -20,26 +20,9 @@
  * SOFTWARE.
  */
 
-/*
- * Copyright 2017 The Netty Project
- * Copyright 2020 The Web eID project
- *
- * The Netty Project and The Web eID Project license this file to you under the
- * Apache License, version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at:
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package eu.webeid.security.validator.ocsp;
 
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
 import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.crypto.Digest;
@@ -52,33 +35,26 @@ import java.io.OutputStream;
 
 /**
  * BouncyCastle's OCSPReqBuilder needs a DigestCalculator but BC doesn't
- * provide any public implementations of that interface. That's why we need to
- * write our own. There's a default SHA-1 implementation and one for SHA-256.
- * Which one to use will depend on the Certificate Authority (CA).
+ * provide any public implementations of it, hence this implementation.
  */
-public final class Digester implements DigestCalculator {
+public final class DigestCalculatorImpl implements DigestCalculator {
+
+    private static final AlgorithmIdentifier SHA1 = new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1);
+    private static final AlgorithmIdentifier SHA256 = new AlgorithmIdentifier(NISTObjectIdentifiers.id_sha256);
 
     private final DigestOutputStream dos;
     private final AlgorithmIdentifier algId;
 
-    public static DigestCalculator sha1() {
-        final Digest digest = new SHA1Digest();
-        final AlgorithmIdentifier algId = new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1);
 
-        return new Digester(digest, algId);
+    public static DigestCalculator sha1() {
+        return new DigestCalculatorImpl(new SHA1Digest(), SHA1);
     }
 
     public static DigestCalculator sha256() {
-        Digest digest = new SHA256Digest();
-
-        // The OID for SHA-256: http://www.oid-info.com/get/2.16.840.1.101.3.4.2.1
-        final ASN1ObjectIdentifier oid = new ASN1ObjectIdentifier("2.16.840.1.101.3.4.2.1").intern();
-        final AlgorithmIdentifier algId = new AlgorithmIdentifier(oid);
-
-        return new Digester(digest, algId);
+        return new DigestCalculatorImpl(new SHA256Digest(), SHA256);
     }
 
-    private Digester(Digest digest, AlgorithmIdentifier algId) {
+    private DigestCalculatorImpl(Digest digest, AlgorithmIdentifier algId) {
         this.dos = new DigestOutputStream(digest);
         this.algId = algId;
     }

--- a/src/main/java/eu/webeid/security/validator/ocsp/OcspResponseValidator.java
+++ b/src/main/java/eu/webeid/security/validator/ocsp/OcspResponseValidator.java
@@ -40,11 +40,9 @@ import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Objects;
-import java.util.TimeZone;
-import java.util.concurrent.TimeUnit;
 
 public final class OcspResponseValidator {
 
@@ -54,8 +52,7 @@ public final class OcspResponseValidator {
      * https://oidref.com/1.3.6.1.5.5.7.3.9
      */
     private static final String OID_OCSP_SIGNING = "1.3.6.1.5.5.7.3.9";
-
-    static final long ALLOWED_TIME_SKEW_MILLIS = TimeUnit.MINUTES.toMillis(15);
+    private static final String ERROR_PREFIX = "Certificate status update time check failed: ";
 
     public static void validateHasSigningExtension(X509Certificate certificate) throws OCSPCertificateException {
         Objects.requireNonNull(certificate, "certificate");
@@ -78,7 +75,7 @@ public final class OcspResponseValidator {
         }
     }
 
-    public static void validateCertificateStatusUpdateTime(SingleResp certStatusResponse) throws UserCertificateOCSPCheckFailedException {
+    public static void validateCertificateStatusUpdateTime(SingleResp certStatusResponse, Duration allowedTimeSkew, Duration maxThisupdateAge) throws UserCertificateOCSPCheckFailedException {
         // From RFC 2560, https://www.ietf.org/rfc/rfc2560.txt:
         // 4.2.2.  Notes on OCSP Responses
         // 4.2.2.1.  Time
@@ -88,18 +85,34 @@ public final class OcspResponseValidator {
         //   SHOULD be considered unreliable.
         //   If nextUpdate is not set, the responder is indicating that newer
         //   revocation information is available all the time.
-        final Date now = DateAndTime.DefaultClock.getInstance().now();
-        final Date notAllowedBefore = new Date(now.getTime() - ALLOWED_TIME_SKEW_MILLIS);
-        final Date notAllowedAfter = new Date(now.getTime() + ALLOWED_TIME_SKEW_MILLIS);
-        final Date thisUpdate = certStatusResponse.getThisUpdate();
-        final Date nextUpdate = certStatusResponse.getNextUpdate() != null ? certStatusResponse.getNextUpdate() : thisUpdate;
-        if (notAllowedAfter.before(thisUpdate) ||
-            notAllowedBefore.after(nextUpdate)) {
-            throw new UserCertificateOCSPCheckFailedException("Certificate status update time check failed: " +
-                "notAllowedBefore: " + toUtcString(notAllowedBefore) +
-                ", notAllowedAfter: " + toUtcString(notAllowedAfter) +
-                ", thisUpdate: " + toUtcString(thisUpdate) +
-                ", nextUpdate: " + toUtcString(certStatusResponse.getNextUpdate()));
+        final Instant now = DateAndTime.DefaultClock.getInstance().now().toInstant();
+        final Instant earliestAcceptableTimeSkew = now.minus(allowedTimeSkew);
+        final Instant latestAcceptableTimeSkew = now.plus(allowedTimeSkew);
+        final Instant minimumValidThisUpdateTime = now.minus(maxThisupdateAge);
+
+        final Instant thisUpdate = certStatusResponse.getThisUpdate().toInstant();
+        if (thisUpdate.isAfter(latestAcceptableTimeSkew)) {
+            throw new UserCertificateOCSPCheckFailedException(ERROR_PREFIX +
+                "thisUpdate '" + thisUpdate + "' is too far in the future, " +
+                "latest allowed: '" + latestAcceptableTimeSkew + "'");
+        }
+        if (thisUpdate.isBefore(minimumValidThisUpdateTime)) {
+            throw new UserCertificateOCSPCheckFailedException(ERROR_PREFIX +
+                "thisUpdate '" + thisUpdate + "' is too old, " +
+                "minimum time allowed: '" + minimumValidThisUpdateTime + "'");
+        }
+
+        if (certStatusResponse.getNextUpdate() == null) {
+            return;
+        }
+        final Instant nextUpdate = certStatusResponse.getNextUpdate().toInstant();
+        if (nextUpdate.isBefore(earliestAcceptableTimeSkew)) {
+            throw new UserCertificateOCSPCheckFailedException(ERROR_PREFIX +
+                "nextUpdate '" + nextUpdate + "' is in the past");
+        }
+        if (nextUpdate.isBefore(thisUpdate)) {
+            throw new UserCertificateOCSPCheckFailedException(ERROR_PREFIX +
+                "nextUpdate '" + nextUpdate + "' is before thisUpdate '" + thisUpdate + "'");
         }
     }
 
@@ -118,15 +131,6 @@ public final class OcspResponseValidator {
         } else {
             throw new UserCertificateRevokedException("Status is neither good, revoked nor unknown");
         }
-    }
-
-    static String toUtcString(Date date) {
-        if (date == null) {
-            return String.valueOf((Object) null);
-        }
-        final SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
-        dateFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return dateFormatter.format(date);
     }
 
     private OcspResponseValidator() {

--- a/src/test/java/eu/webeid/security/testutil/AuthTokenValidators.java
+++ b/src/test/java/eu/webeid/security/testutil/AuthTokenValidators.java
@@ -89,6 +89,10 @@ public final class AuthTokenValidators {
             .build();
     }
 
+    public static AuthTokenValidatorBuilder getDefaultAuthTokenValidatorBuilder() throws CertificateException, IOException {
+        return getAuthTokenValidatorBuilder(TOKEN_ORIGIN_URL, getCACertificates());
+    }
+
     private static AuthTokenValidatorBuilder getAuthTokenValidatorBuilder(String uri, X509Certificate[] certificates) {
         return new AuthTokenValidatorBuilder()
             .withSiteOrigin(URI.create(uri))

--- a/src/test/java/eu/webeid/security/testutil/DateMocker.java
+++ b/src/test/java/eu/webeid/security/testutil/DateMocker.java
@@ -23,19 +23,23 @@
 package eu.webeid.security.testutil;
 
 import com.fasterxml.jackson.databind.util.StdDateFormat;
+import eu.webeid.security.util.DateAndTime;
+import io.jsonwebtoken.Clock;
+import org.mockito.MockedStatic;
 
 import java.text.ParseException;
 import java.util.Date;
 
-public final class Dates {
+public class DateMocker {
+
     private static final StdDateFormat STD_DATE_FORMAT = new StdDateFormat();
 
-    public static Date create(String iso8601Date) {
+    public static void mockDate(String iso8601Date, MockedStatic<DateAndTime.DefaultClock> mockedClock) {
         try {
-            return STD_DATE_FORMAT.parse(iso8601Date);
+            final Date theDate = STD_DATE_FORMAT.parse(iso8601Date);
+            mockedClock.when(DateAndTime.DefaultClock::getInstance).thenReturn((Clock) () -> theDate);
         } catch (ParseException e) {
             throw new RuntimeException(e);
         }
     }
-
 }

--- a/src/test/java/eu/webeid/security/validator/AuthTokenValidatorBuilderTest.java
+++ b/src/test/java/eu/webeid/security/validator/AuthTokenValidatorBuilderTest.java
@@ -26,10 +26,15 @@ import eu.webeid.security.testutil.AuthTokenValidators;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class AuthTokenValidatorBuilderTest {
+public class AuthTokenValidatorBuilderTest {
+
+    // AuthTokenValidationConfiguration has a package-private constructor, but some tests need access to it outside its package.
+    // Provide a public accessor to it for these tests.
+    public static final AuthTokenValidationConfiguration CONFIGURATION = new AuthTokenValidationConfiguration();
 
     final AuthTokenValidatorBuilder builder = new AuthTokenValidatorBuilder();
 
@@ -81,4 +86,30 @@ class AuthTokenValidatorBuilderTest {
             .hasMessageStartingWith("An URI syntax exception occurred");
     }
 
+    @Test
+    void testInvalidOcspResponseTimeSkew() throws Exception {
+        final AuthTokenValidatorBuilder builderWithInvalidOcspResponseTimeSkew = AuthTokenValidators.getDefaultAuthTokenValidatorBuilder()
+            .withAllowedOcspResponseTimeSkew(Duration.ofMinutes(-1));
+        assertThatThrownBy(builderWithInvalidOcspResponseTimeSkew::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageStartingWith("Allowed OCSP response time-skew must be greater than zero");
+    }
+
+    @Test
+    void testInvalidMaxOcspResponseThisUpdateAge() throws Exception {
+        final AuthTokenValidatorBuilder builderWithInvalidOcspResponseTimeSkew = AuthTokenValidators.getDefaultAuthTokenValidatorBuilder()
+            .withMaxOcspResponseThisUpdateAge(Duration.ZERO);
+        assertThatThrownBy(builderWithInvalidOcspResponseTimeSkew::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageStartingWith("Max OCSP response thisUpdate age must be greater than zero");
+    }
+
+    @Test
+    void testInvalidOcspRequestTimeout() throws Exception {
+        final AuthTokenValidatorBuilder builderWithInvalidOcspResponseTimeSkew = AuthTokenValidators.getDefaultAuthTokenValidatorBuilder()
+            .withOcspRequestTimeout(Duration.ofMinutes(-1));
+        assertThatThrownBy(builderWithInvalidOcspResponseTimeSkew::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageStartingWith("OCSP request timeout must be greater than zero");
+    }
 }

--- a/src/test/java/eu/webeid/security/validator/ocsp/OcspClientOverrideTest.java
+++ b/src/test/java/eu/webeid/security/validator/ocsp/OcspClientOverrideTest.java
@@ -52,7 +52,7 @@ class OcspClientOverrideTest extends AbstractTestWithValidator {
 
     @Test
     @Disabled("Demonstrates how to configure the built-in HttpClient instance for OcspClientImpl")
-    void whenOkHttpOcspClientIsExtended_thenOcspCallSucceeds() throws JceException, CertificateException, IOException {
+    void whenOcspClientIsConfiguredWithCustomHttpClient_thenOcspCallSucceeds() throws JceException, CertificateException, IOException {
         final AuthTokenValidator validator = AuthTokenValidators.getAuthTokenValidatorWithOverriddenOcspClient(
             new OcspClientImpl(HttpClient.newBuilder().build(), Duration.ofSeconds(5))
         );


### PR DESCRIPTION
WE2-868

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/web-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Mart Somermaa <mrts@users.noreply.github.com>