### PR TITLE
Make SubjectCertificateNotRevokedValidator thread-safe

### DIFF
--- a/src/main/java/eu/webeid/security/validator/certvalidators/SubjectCertificateNotRevokedValidator.java
+++ b/src/main/java/eu/webeid/security/validator/certvalidators/SubjectCertificateNotRevokedValidator.java
@@ -60,7 +60,6 @@ import java.util.Objects;
 public final class SubjectCertificateNotRevokedValidator {
 
     private static final Logger LOG = LoggerFactory.getLogger(SubjectCertificateNotRevokedValidator.class);
-    private static final DigestCalculator DIGEST_CALCULATOR = DigestCalculatorImpl.sha1();
 
     private final SubjectCertificateTrustedValidator trustValidator;
     private final OcspClient ocspClient;
@@ -197,7 +196,8 @@ public final class SubjectCertificateNotRevokedValidator {
 
     private static CertificateID getCertificateId(X509Certificate subjectCertificate, X509Certificate issuerCertificate) throws CertificateEncodingException, IOException, OCSPException {
         final BigInteger serial = subjectCertificate.getSerialNumber();
-        return new CertificateID(DIGEST_CALCULATOR,
+        final DigestCalculator digestCalculator = DigestCalculatorImpl.sha1();
+        return new CertificateID(digestCalculator,
             new X509CertificateHolder(issuerCertificate.getEncoded()), serial);
     }
 


### PR DESCRIPTION
Make `SubjectCertificateNotRevokedValidator` thread-safe by creating a new `DigestCalculator` each time `SubjectCertificateNotRevokedValidator.getCertificateId()` is called.

WE2-1068

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/web-eid/.github/blob/master/CONTRIBUTING.md!
-->
Signed-off-by: Mart Somermaa <mrts@users.noreply.github.com>
