### PR TITLE
Update web-eid-authtoken-validation-java dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,6 @@
     <name>authtoken-validation</name>
     <description>Web eID authentication token validation library for Java</description>
 
-    <prerequisites>
-        <maven>3.6.3</maven>
-    </prerequisites>
-
     <properties>
         <java.version>11</java.version>
         <jjwt.version>0.12.6</jjwt.version>
@@ -26,6 +22,7 @@
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+        <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <jacoco.version>0.8.12</jacoco.version>
         <sonar.coverage.jacoco.xmlReportPaths>
             ${project.basedir}/../jacoco-coverage-report/target/site/jacoco-aggregate/jacoco.xml
@@ -151,6 +148,26 @@
                         <goals>
                             <goal>report</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven-enforcer-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[3.6.3,)</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
         <bouncycastle.version>1.80</bouncycastle.version>
         <jackson.version>2.18.3</jackson.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <junit-jupiter.version>5.12.0</junit-jupiter.version>
+        <junit-jupiter.version>5.12.1</junit-jupiter.version>
         <assertj.version>3.27.3</assertj.version>
-        <mockito.version>5.16.0</mockito.version>
+        <mockito.version>5.17.0</mockito.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>


### PR DESCRIPTION
- **Update web-eid-authtoken-validation-java dependencies**
- **Fix warning: uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin**
- Mismatching maven version will produce an error message: The plugin org.apache.maven.plugins:maven-enforcer-plugin:3.5.0 requires Maven version 3.6.3

Signed-off-by: Sven Mitt <svenzik@users.noreply.github.com> 
