### PR TITLE
bump spring-boot to 3.5.13 and force thymeleaf to 3.1.4.RELEASE

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.10</version>
+		<version>3.5.13</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>eu.webeid.example</groupId>
@@ -23,6 +23,9 @@
 		<digidoc4j.version>6.1.1</digidoc4j.version>
 		<jmockit.version>1.44</jmockit.version> <!-- Keep version 1.44, otherwise mocking will fail. -->
 		<jib.version>3.5.1</jib.version>
+
+        <!-- Remove explicit thymeleaf version override when spring boot uses thymeleaf 3.1.4.RELEASE or later: CVE-2026-40477, CVE-2026-40478, CVE-2026-40477, CVE-2026-40478 -->
+        <thymeleaf.version>3.1.4.RELEASE</thymeleaf.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
bump spring-boot to 3.5.13 and force thymeleaf to 3.1.4.RELEASE

Signed-off-by: Sven Mitt <svenzik@users.noreply.github.com>
