### PR TITLE
bump DigiDoc4j to version 6.1.1

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -20,7 +20,7 @@
 		<java.version>17</java.version>
 		<maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
 		<webeid.version>3.2.1-SNAPSHOT</webeid.version>
-		<digidoc4j.version>6.1.0</digidoc4j.version>
+		<digidoc4j.version>6.1.1</digidoc4j.version>
 		<jmockit.version>1.44</jmockit.version> <!-- Keep version 1.44, otherwise mocking will fail. -->
 		<jib.version>3.5.1</jib.version>
 	</properties>


### PR DESCRIPTION
bump DigiDoc4j to version 6.1.1

Signed-off-by: Sven Mitt <svenzik@users.noreply.github.com>
