### PR TITLE
Update mock dates in tests and update jackson-databind to 2.22.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <java.version>11</java.version>
         <jjwt.version>0.13.0</jjwt.version>
         <bouncycastle.version>1.84</bouncycastle.version>
-        <jackson.version>2.22.0</jackson.version>
+        <jackson.version>2.22.1</jackson.version>
         <slf4j.version>2.0.17</slf4j.version>
         <junit-jupiter.version>5.14.4</junit-jupiter.version>
         <assertj.version>3.27.7</assertj.version>

--- a/src/test/java/eu/webeid/security/validator/AuthTokenAlgorithmTest.java
+++ b/src/test/java/eu/webeid/security/validator/AuthTokenAlgorithmTest.java
@@ -22,15 +22,36 @@
 
 package eu.webeid.security.validator;
 
-import org.junit.jupiter.api.Test;
 import eu.webeid.security.authtoken.WebEidAuthToken;
-import eu.webeid.security.exceptions.AuthTokenParseException;
 import eu.webeid.security.exceptions.AuthTokenException;
+import eu.webeid.security.exceptions.AuthTokenParseException;
 import eu.webeid.security.testutil.AbstractTestWithValidator;
+import eu.webeid.security.util.DateAndTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
+import static eu.webeid.security.testutil.DateMocker.mockDate;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mockStatic;
 
 class AuthTokenAlgorithmTest extends AbstractTestWithValidator {
+    private MockedStatic<DateAndTime.DefaultClock> mockedClock;
+
+    @Override
+    @BeforeEach
+    protected void setup() {
+        super.setup();
+        mockedClock = mockStatic(DateAndTime.DefaultClock.class);
+        // Ensure that the certificates do not expire.
+        mockDate("2021-07-23", mockedClock);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedClock.close();
+    }
 
     @Test
     void whenAlgorithmNone_thenValidationFails() throws AuthTokenException {

--- a/src/test/java/eu/webeid/security/validator/AuthTokenSignatureTest.java
+++ b/src/test/java/eu/webeid/security/validator/AuthTokenSignatureTest.java
@@ -28,7 +28,10 @@ import eu.webeid.security.exceptions.AuthTokenSignatureValidationException;
 import eu.webeid.security.testutil.AbstractTestWithValidator;
 import eu.webeid.security.testutil.AuthTokenValidators;
 import eu.webeid.security.util.DateAndTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import java.security.cert.X509Certificate;
 
@@ -45,6 +48,22 @@ class AuthTokenSignatureTest extends AbstractTestWithValidator {
         "\"appVersion\":\"https://web-eid.eu/web-eid-app/releases/2.0.0+0\"," +
         "\"signature\":\"arx164xRiwhIQDINe0J+ZxJWZFOQTx0PBtOaWaxAe7gofEIHRIbV1w0sOCYBJnvmvMem9hU4nc2+iJx2x8poYck4Z6eI3GwtiksIec3XQ9ZIk1n/XchXnmPn3GYV+HzJ\"," +
         "\"format\":\"web-eid:1.0\"}";
+
+    private MockedStatic<DateAndTime.DefaultClock> mockedClock;
+
+    @Override
+    @BeforeEach
+    protected void setup() {
+        super.setup();
+        mockedClock = mockStatic(DateAndTime.DefaultClock.class);
+        // Ensure that the certificates do not expire.
+        mockDate("2021-07-23", mockedClock);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedClock.close();
+    }
 
     @Test
     void whenValidTokenAndNonce_thenValidationSucceeds() throws Exception {
@@ -80,15 +99,11 @@ class AuthTokenSignatureTest extends AbstractTestWithValidator {
 
     @Test
     void whenTokenWithWrongCert_thenValidationFails() throws Exception {
-        // Ensure that the certificate does not expire.
-        try (final var mockedClock = mockStatic(DateAndTime.DefaultClock.class)) {
-            mockDate("2024-08-01", mockedClock);
-            final AuthTokenValidator authTokenValidator = AuthTokenValidators.getAuthTokenValidator();
-            final WebEidAuthToken authTokenWithWrongCert = authTokenValidator.parse(AUTH_TOKEN_WRONG_CERT);
-            assertThatThrownBy(() -> authTokenValidator
-                .validate(authTokenWithWrongCert, VALID_CHALLENGE_NONCE))
-                .isInstanceOf(AuthTokenSignatureValidationException.class);
-        }
+        final AuthTokenValidator authTokenValidator = AuthTokenValidators.getAuthTokenValidator();
+        final WebEidAuthToken authTokenWithWrongCert = authTokenValidator.parse(AUTH_TOKEN_WRONG_CERT);
+        assertThatThrownBy(() -> authTokenValidator
+            .validate(authTokenWithWrongCert, VALID_CHALLENGE_NONCE))
+            .isInstanceOf(AuthTokenSignatureValidationException.class);
     }
 
 }

--- a/src/test/java/eu/webeid/security/validator/ocsp/OcspClientOverrideTest.java
+++ b/src/test/java/eu/webeid/security/validator/ocsp/OcspClientOverrideTest.java
@@ -25,11 +25,15 @@ package eu.webeid.security.validator.ocsp;
 import eu.webeid.security.exceptions.JceException;
 import eu.webeid.security.testutil.AbstractTestWithValidator;
 import eu.webeid.security.testutil.AuthTokenValidators;
+import eu.webeid.security.util.DateAndTime;
 import eu.webeid.security.validator.AuthTokenValidator;
 import org.bouncycastle.cert.ocsp.OCSPReq;
 import org.bouncycastle.cert.ocsp.OCSPResp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import java.io.IOException;
 import java.net.URI;
@@ -37,10 +41,27 @@ import java.net.http.HttpClient;
 import java.security.cert.CertificateException;
 import java.time.Duration;
 
+import static eu.webeid.security.testutil.DateMocker.mockDate;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mockStatic;
 
 class OcspClientOverrideTest extends AbstractTestWithValidator {
+    private MockedStatic<DateAndTime.DefaultClock> mockedClock;
+
+    @Override
+    @BeforeEach
+    protected void setup() {
+        super.setup();
+        mockedClock = mockStatic(DateAndTime.DefaultClock.class);
+        // Ensure that the certificates do not expire.
+        mockDate("2021-07-23", mockedClock);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedClock.close();
+    }
 
     @Test
     void whenOcspClientIsOverridden_thenItIsUsed() throws JceException, CertificateException, IOException {


### PR DESCRIPTION
Update mock dates in tests due to expired test cert

Signed-off-by: Mart Aarma <mart.aarma@nortal.com>